### PR TITLE
Preferred settings on Series 1

### DIFF
--- a/TypeAMachines_ProMatte.ini
+++ b/TypeAMachines_ProMatte.ini
@@ -1,0 +1,266 @@
+[profile]
+extrusion_width = 0.5
+shell_numbers = 2
+infill_percentage = 6.25
+layer_height = 0.2
+wall_thickness = 1.0
+retraction_enable = True
+solid_layer_thickness = 0.8
+infill_type = 3D
+fill_distance = 8
+nozzle_size = 0.4
+print_speed = 40
+print_temperature = 185
+print_temperature2 = 0
+print_temperature3 = 0
+print_temperature4 = 0
+print_temperature5 = 0
+print_bed_temperature = 50
+support = None
+platform_adhesion = None
+support_dual_extrusion = Both
+wipe_tower = False
+wipe_tower_volume = 15
+ooze_shield = False
+retraction_speed = 50
+retraction_amount = 1.0
+retraction_dual_amount = 16.5
+retraction_min_travel = 1.5
+retraction_combing = True
+retraction_minimal_extrusion = 0.02
+retraction_hop = 0.0
+bottom_thickness = 0.2
+layer0_width_factor = 100
+object_sink = 0.0
+overlap_dual = 0.15
+travel_speed = 200.0
+bottom_layer_speed = 30
+infill_speed = 0.0
+solidarea_speed = 0.0
+inset0_speed = 0.0
+insetx_speed = 0.0
+cool_min_layer_time = 8
+fan_enabled = True
+filament_diameter = 1.75
+filament_diameter2 = 0
+filament_diameter3 = 0
+filament_diameter4 = 0
+filament_diameter5 = 0
+filament_flow = 100
+skirt_line_count = 1
+skirt_gap = 3.0
+skirt_minimal_length = 150.0
+fan_full_height = 5
+fan_speed = 100
+fan_speed_max = 100
+cool_min_feedrate = 10
+cool_head_lift = False
+2d_infill_type = Automatic
+solid_top = True
+solid_bottom = True
+fill_overlap = 15
+perimeter_before_infill = True
+support_type = Lines
+support_angle = 45
+support_fill_rate = 4.0
+support_xy_distance = 0.7
+support_z_distance = 0.2
+spiralize = False
+simple_mode = False
+brim_line_count = 10
+raft_margin = 5.0
+raft_line_spacing = 3.0
+raft_base_thickness = 0.3
+raft_base_linewidth = 0.7
+raft_interface_thickness = 0.2
+raft_interface_linewidth = 0.2
+raft_airgap_all = 0
+raft_airgap = 0.2
+raft_surface_layers = 2
+raft_surface_thickness = 0.27
+raft_surface_linewidth = 0.4
+fix_horrible_union_all_type_a = True
+fix_horrible_union_all_type_b = False
+fix_horrible_use_open_bits = False
+fix_horrible_extensive_stitching = False
+plugin_config = 
+object_center_x = -1
+object_center_y = -1
+
+[alterations]
+start.gcode = 
+	;-- START GCODE --
+	;Sliced for Type A Machines Series 1
+	;Sliced at: {day} {date} {time}
+	;Basic settings:
+	; Layer height: {layer_height}
+	; Walls: {wall_thickness}
+	; Fill: {fill_distance}
+	; Print Speed: {print_speed}
+	; Support: {support}
+	; Retraction Speed: {retraction_speed}
+	; Retraction Distance: {retraction_amount}
+	;Print time: {print_time}
+	;Filament used: {filament_amount}m {filament_weight}g
+	;Settings based on: {material_profile}
+	G21        ;metric values
+	G90        ;absolute positioning
+	G28     ;move to endstops
+	G29		;allows for auto-levelling
+	G1 Z15.0 F12000 ;move the platform down 15mm
+	G1 X150 Y5 F{travel_speed} ;center
+	M140 S{print_bed_temperature} ;Prep Heat Bed
+	M109 S{print_temperature} ;Heat To temp
+	M190 S{print_bed_temperature} ;Heat Bed to temp
+	G1 X150 Y5 Z0.3 ;move the platform to purge extrusion
+	G92 E0 ;zero the extruded length
+	G1 F200 X250 E30 ;extrude 30mm of feed stock
+	G92 E0 ;zero the extruded length again
+	G1 X150 Y150  Z25 F12000 ;recenter and begin
+	G1 F{travel_speed}
+end.gcode = 
+	;-- END GCODE --
+	M104 S0     ;extruder heater off
+	M140 S0     ;heated bed heater off (if you have it)
+	G91         ;relative positioning
+	G1 E-1 F300   ;retract the filament a bit before lifting the nozzle, to release some of the pressure
+	G1 Z+0.5 E-5 X-20 Y-20 F{travel_speed} ;move Z up a bit and retract filament even more
+	G28 X0 Y0     ;move X/Y to min endstops, so the head is out of the way
+	M84           ;steppers off
+	G90           ;absolute positioning
+	;{profile_string}
+start2.gcode = ;-- START GCODE --
+	;Sliced for Type A Machines Series 1
+	;Sliced at: {day} {date} {time}
+	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_distance}
+	;Print Speed: {print_speed} Support: {support}
+	;Retraction Speed: {retraction_speed} Retraction Distance: {retraction_amount}
+	;Print time: {print_time}
+	;Filament used: {filament_amount}m {filament_weight}g
+	;Filament cost: {filament_cost}
+	G21        ;metric values
+	G90        ;absolute positioning
+	G28     ;move to endstops
+	G29		;allows for auto-levelling
+	G1 Z15.0 F12000 ;move the platform down 15mm
+	G1 X150 Y5 F{travel_speed} ;center
+	M109 S{print_temperature} ;Heat To temp
+	G1 X150 Y5 Z0.3 ;move the platform to purge extrusion
+	G92 E0 ;zero the extruded length
+	G1 F200 X250 E30 ;extrude 30mm of feed stock
+	G92 E0 ;zero the extruded length again
+	G1 X150 Y150  Z25 F12000 ;recenter and begin
+	G1 F{travel_speed}
+end2.gcode = ;-- END GCODE --
+	M104 S0     ;extruder heater off
+	G91         ;relative positioning
+	G1 E-1 F300   ;retract the filament a bit before lifting the nozzle, to release some of the pressure
+	G1 Z+0.5 E-5 X-20 Y-20 F9000 ;move Z up a bit and retract filament even more
+	G28 X0 Y0     ;move X/Y to min endstops, so the head is out of the way
+	M84           ;steppers off
+	G90           ;absolute positioning
+start3.gcode = ;Sliced at: {day} {date} {time}
+	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_distance}
+	;Print time: {print_time}
+	;Filament used: {filament_amount}m {filament_weight}g
+	;Filament cost: {filament_cost}
+	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
+	;M104 S{print_temperature} ;Uncomment to add your own temperature line
+	;M109 T1 S{print_temperature2} ;Uncomment to add your own temperature line
+	;M109 T0 S{print_temperature} ;Uncomment to add your own temperature line
+	G21        ;metric values
+	G90        ;absolute positioning
+	M107       ;start with the fan off
+	G28 X0 Y0  ;move X/Y to min endstops
+	G28 Z0     ;move Z to min endstops
+	G1 Z15.0 F{travel_speed} ;move the platform down 15mm
+	T2                      ;Switch to the 3rd extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F200 E-{retraction_dual_amount}
+	T1                      ;Switch to the 2nd extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F200 E-{retraction_dual_amount}
+	T0                      ;Switch to the first extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F{travel_speed}
+	;Put printing message on LCD screen
+	M117 Printing...
+end3.gcode = ;End GCode
+	M104 T0 S0                     ;extruder heater off
+	M104 T1 S0                     ;extruder heater off
+	M104 T2 S0                     ;extruder heater off
+	M140 S0                     ;heated bed heater off (if you have it)
+	G91                                    ;relative positioning
+	G1 E-1 F300                            ;retract the filament a bit before lifting the nozzle, to release some of the pressure
+	G1 Z+0.5 E-5 X-20 Y-20 F{travel_speed} ;move Z up a bit and retract filament even more
+	G28 X0 Y0                              ;move X/Y to min endstops, so the head is out of the way
+	M84                         ;steppers off
+	G90                         ;absolute positioning
+	;{profile_string}
+start4.gcode = ;Sliced at: {day} {date} {time}
+	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_distance}
+	;Print time: {print_time}
+	;Filament used: {filament_amount}m {filament_weight}g
+	;Filament cost: {filament_cost}
+	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
+	;M104 S{print_temperature} ;Uncomment to add your own temperature line
+	;M109 T2 S{print_temperature2} ;Uncomment to add your own temperature line
+	;M109 T1 S{print_temperature2} ;Uncomment to add your own temperature line
+	;M109 T0 S{print_temperature} ;Uncomment to add your own temperature line
+	G21        ;metric values
+	G90        ;absolute positioning
+	M107       ;start with the fan off
+	G28 X0 Y0  ;move X/Y to min endstops
+	G28 Z0     ;move Z to min endstops
+	G1 Z15.0 F{travel_speed} ;move the platform down 15mm
+	T3                      ;Switch to the 4th extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F200 E-{retraction_dual_amount}
+	T2                      ;Switch to the 3rd extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F200 E-{retraction_dual_amount}
+	T1                      ;Switch to the 2nd extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F200 E-{retraction_dual_amount}
+	T0                      ;Switch to the first extruder
+	G92 E0                  ;zero the extruded length
+	G1 F200 E10             ;extrude 10mm of feed stock
+	G92 E0                  ;zero the extruded length again
+	G1 F{travel_speed}
+	;Put printing message on LCD screen
+	M117 Printing...
+end4.gcode = ;End GCode
+	M104 T0 S0                     ;extruder heater off
+	M104 T1 S0                     ;extruder heater off
+	M104 T2 S0                     ;extruder heater off
+	M104 T3 S0                     ;extruder heater off
+	M140 S0                     ;heated bed heater off (if you have it)
+	G91                                    ;relative positioning
+	G1 E-1 F300                            ;retract the filament a bit before lifting the nozzle, to release some of the pressure
+	G1 Z+0.5 E-5 X-20 Y-20 F{travel_speed} ;move Z up a bit and retract filament even more
+	G28 X0 Y0                              ;move X/Y to min endstops, so the head is out of the way
+	M84                         ;steppers off
+	G90                         ;absolute positioning
+	;{profile_string}
+support_start.gcode = 
+support_end.gcode = 
+cool_start.gcode = 
+cool_end.gcode = 
+replace.csv = 
+preswitchextruder.gcode = ;Switch between the current extruder and the next extruder, when printing with multiple extruders.
+	;This code is added before the T(n)
+postswitchextruder.gcode = ;Switch between the current extruder and the next extruder, when printing with multiple extruders.
+	;This code is added after the T(n)
+


### PR DESCRIPTION
Material tested on TAM Series 1 Pro 2016 model 3D printer. These settings should be functional on most 3D printers with a 0.4 nozzle. The settings were focused for finish and minimization of post processing. Due to this print speed was reduced and print time increased.